### PR TITLE
Support not creating namespace

### DIFF
--- a/chubaofs/Chart.yaml
+++ b/chubaofs/Chart.yaml
@@ -9,7 +9,6 @@ keywords:
   - chubaofs
   - chubaofs-helm
   - chubaofs-csi
-home: https://chubao.io
 sources:
   - https://github.com/chubaofs/chubaofs-helm
 icon: https://raw.githubusercontent.com/chubaofs/chubaofs-helm/master/assets/chubaofs-logo.png

--- a/chubaofs/templates/namespace.yaml
+++ b/chubaofs/templates/namespace.yaml
@@ -1,4 +1,6 @@
+{{- if .Values.createNamespace }}
 apiVersion: v1
 kind: Namespace
 metadata:
   name: {{ .Values.namespace }}
+{{ end }}

--- a/chubaofs/values.yaml
+++ b/chubaofs/values.yaml
@@ -1,4 +1,5 @@
 
+createNamespace: true
 namespace: chubaofs
 
 component:


### PR DESCRIPTION
The chart should not create the namespace.

Doing so, it's not installable on some tools like `helm-operator` where the helm release definition live in the namespace, and so the namespace is already created by another way. 