### PR TITLE
[BugFix] Do not create unused virtual hosts in Ingress object

### DIFF
--- a/cubefs/templates/ingress.yaml
+++ b/cubefs/templates/ingress.yaml
@@ -13,25 +13,32 @@ metadata:
 spec:
   rules:
 {{- if semverCompare "<1.19.0" (include "cubefs.kubernetes.version" .) }}
+  {{- if .Values.component.master }}
     - host: {{ .Values.master.host }}
       http:
         paths:
           - backend:
               serviceName: master-service
               servicePort: {{ .Values.master.port }}
+  {{- end }}
+  {{- if .Values.component.monitor }}
     - host: {{ .Values.grafana.host }}
       http:
         paths:
           - backend:
               serviceName: grafana-service
               servicePort: {{ .Values.grafana.port }}
+  {{- end }}
+  {{- if .Values.component.objectnode }}
     - host: {{ .Values.objectnode.host }}
       http:
         paths:
           - backend:
               serviceName: objectnode-service
               servicePort: {{ .Values.objectnode.port }}
+  {{- end }}
 {{- else }}
+  {{- if .Values.component.master }}
     - host: {{ .Values.master.host }}
       http:
         paths:
@@ -42,6 +49,8 @@ spec:
                   number: {{ .Values.master.port }}
             path: /
             pathType: Prefix
+  {{- end }}
+  {{- if .Values.component.monitor }}
     - host: {{ .Values.grafana.host }}
       http:
         paths:
@@ -52,6 +61,8 @@ spec:
                   number: {{ .Values.grafana.port }}
             path: /
             pathType: Prefix
+  {{- end }}
+  {{- if .Values.component.objectnode }}
     - host: {{ .Values.objectnode.host }}
       http:
         paths:
@@ -62,5 +73,6 @@ spec:
                   number: {{ .Values.objectnode.port }}
             path: /
             pathType: Prefix
+  {{- end }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
When deploying the chart deactivating some services (*monitor* for example), `Ingress` is created with unused virtual host records.

This can cause confusion with service auto-discovery tools such as https://github.com/kubernetes-sigs/external-dns that will publish broken sites.

The idea behind this PR is to record virtual host only if the backend component is deployed.