### PR TITLE
Fixed label for CSI matching nodeSelector in values.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ kubectl label node <nodename> component.cubefs.io/master=enabled
 kubectl label node <nodename> component.cubefs.io/metanode=enabled
 kubectl label node <nodename> component.cubefs.io/datanode=enabled
 kubectl label node <nodename> component.cubefs.io/objectnode=enabled
-kubectl label node <nodename> cubefs-csi-node=enabled
+kubectl label node <nodename> component.cubefs.io/csi=enabled
 ```
 
 ### Deploy Cubefs cluster


### PR DESCRIPTION
Currently, the documentation states that the command to label a CSI node as enabled is `kubectl label node <nodename> cubefs-csi-node=enabled`.

However, in the `values.yml` file, the nodeSelector is `"component.cubefs.io/csi": "enabled"`

This PR updates the README.md file to reflect the correct command.