### PR TITLE
fix: migrate from k8s.gcr.io to registry.k8s.io

### DIFF
--- a/cubefs/values.yaml
+++ b/cubefs/values.yaml
@@ -19,10 +19,10 @@ image:
 
   # CSI related images
   csi_driver: ghcr.io/cubefs/cfs-csi-driver:3.2.0.150.0
-  csi_provisioner: k8s.gcr.io/sig-storage/csi-provisioner:v2.2.2
-  csi_attacher: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
-  csi_resizer: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
-  driver_registrar: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.5.0
+  csi_provisioner: registry.k8s.io/sig-storage/csi-provisioner:v2.2.2
+  csi_attacher: registry.k8s.io/sig-storage/csi-attacher:v3.4.0
+  csi_resizer: registry.k8s.io/sig-storage/csi-resizer:v1.3.0
+  driver_registrar: registry.k8s.io/sig-storage/csi-node-driver-registrar:v2.5.0
 
   grafana: grafana/grafana:6.4.4
   prometheus: prom/prometheus:v2.13.1


### PR DESCRIPTION
Kubernetes is migrating its image registry from [k8s.gcr.io](http://k8s.gcr.io/) to [registry.k8s.io](http://registry.k8s.io/).

Part of kubernetes/k8s.io#4780.