### PR TITLE
Fix Image Tags in Helm Chart for cfs-client and cfs-server

### DIFF
--- a/cubefs/values.yaml
+++ b/cubefs/values.yaml
@@ -19,8 +19,8 @@ kubernetes:
   version: ""
 
 image:
-  server: cubefs/cfs-server:3.2.0
-  client: cubefs/cfs-client:3.2.0
+  server: cubefs/cfs-server:v3.2.0
+  client: cubefs/cfs-client:v3.2.0
   blobstore: cubefs/blobstore:3.3.0
 
   # CSI related images


### PR DESCRIPTION
Fixes [Issue 28](https://github.com/cubefs/cubefs-helm/issues/28)

The Helm chart's image tags for cfs-client and cfs-server are currently set as 3.2.0. However, the corresponding images on DockerHub are tagged with a v prefix, i.e., v3.2.0.

This discrepancy is causing Kubernetes to throw an ImagePullBackOff error, as it's unable to find the images tagged as 3.2.0.

This PR addresses this issue by updating the image tags in the Helm chart to match those on DockerHub, changing them from 3.2.0 to v3.2.0.