### PR TITLE
fix the usage of .Values in statefulset-master.yaml

### DIFF
--- a/cubefs/templates/statefulset-master.yaml
+++ b/cubefs/templates/statefulset-master.yaml
@@ -77,7 +77,7 @@ spec:
             - name: CBFS_METANODE_RESERVED_MEM
               value: {{ .Values.master.metanode_reserved_mem | quote }}
             - name: CBFS_LEGACY_DATA_MEDIA_TYPE
-              value: {{ .Value.master.legacy_data_media_type | quote }}
+              value: {{ .Values.master.legacy_data_media_type | quote }}
             - name: POD_IP
               valueFrom:
                 fieldRef:


### PR DESCRIPTION
helm install... meet error: `Error: template: cubefs/templates/statefulset-master.yaml:80:30: executing "cubefs/templates/statefulset-master.yaml" at <.Value.master.legacy_data_media_type>: nil pointer evaluating interface {}.master`

so I fix it.